### PR TITLE
Only trigger updates for the specific values that change.

### DIFF
--- a/VoiceMeeterPlugin/Commands/Bases/BooleanBaseCommand.cs
+++ b/VoiceMeeterPlugin/Commands/Bases/BooleanBaseCommand.cs
@@ -61,7 +61,7 @@
                     var name = Remote.GetTextParameter($"{(this.IsStrip ? "Strip" : "Bus")}[{hi + this.Offset}].Label");
                     var groupName = String.IsNullOrEmpty(name) ? this.IsStrip ? "Strip" : "Bus" : name;
                     this.AddParameter(
-                        $"VM-Strip{hi}-{cmd}{special}",
+                        GetActionParameterName(hi,cmd,special),
                         $"{this.DisplayName}{special}",
                         $"{groupName} ({hi + 1 + this.Offset})",
                         "Input"
@@ -89,7 +89,7 @@
                 var name = Remote.GetTextParameter($"{(this.IsStrip ? "Strip" : "Bus")}[{hi + this.Offset}].Label");
                 var groupName = String.IsNullOrEmpty(name) ? this.IsStrip ? "Strip" : "Bus" : name;
                 this.AddParameter(
-                    $"VM-Strip{hi}-{cmd}2147483647",
+                    GetActionParameterName(hi,cmd),
                     this.DisplayName,
                     $"{groupName} ({hi + 1 + this.Offset})",
                     "Input"
@@ -98,6 +98,9 @@
 
             this.GetNewSettings();
         }
+        private static String GetActionParameterName(Int32 stripNumber, String cmd, Int32? specialNumber = null) =>
+            specialNumber == null ? $"VM-Strip{stripNumber}-{cmd}2147483647" : $"VM-Strip{stripNumber}-{cmd}{specialNumber.Value}";
+        
 
         private void GetNewSettings()
         {
@@ -108,28 +111,34 @@
                     var hi = this.Actions[hiIndex];
                     for (var index = 1; index <= hi.Length; index++)
                     {
+                        var old = hi[index - 1];
                         hi[index - 1] =
                             (Int32)Remote.GetParameter(
                                 $"{(this.IsStrip ? "Strip" : "Bus")}[{hiIndex + this.Offset}].{this.Command}{index}") ==
                             1;
+                        if (this.Loaded && old != hi[index - 1])
+                        {
+                            this.ActionImageChanged(GetActionParameterName(index, this.Command, hiIndex));
+                        }
                     }
                 }
             }
             else
             {
-                var hiArray = this.Actions[0];
-                for (var hiIndex = 0; hiIndex < hiArray.Length; hiIndex++)
+                var hi = this.Actions[0];
+                for (var index = 0; index < hi.Length; index++)
                 {
-                    hiArray[hiIndex] =
+                    var old = hi[index];
+                    hi[index] =
                         (Int32)Remote.GetParameter(
-                            $"{(this.IsStrip ? "Strip" : "Bus")}[{hiIndex + this.Offset}].{this.Command}") == 1;
+                            $"{(this.IsStrip ? "Strip" : "Bus")}[{index + this.Offset}].{this.Command}") == 1;
+                    if (this.Loaded && old != hi[index])
+                    {
+                        this.ActionImageChanged(GetActionParameterName(index, this.Command));
+                    }
                 }
             }
 
-            if (this.Loaded)
-            {
-            	this.ActionImageChanged();
-            }
         }
 
         protected override Boolean OnLoad()

--- a/VoiceMeeterPlugin/Commands/Bases/SingleBaseAdjustment.cs
+++ b/VoiceMeeterPlugin/Commands/Bases/SingleBaseAdjustment.cs
@@ -69,7 +69,7 @@
                 var name = Remote.GetTextParameter($"{(this.IsStrip ? "Strip" : "Bus")}[{hi + this.Offset}].Label");
                 var groupName = String.IsNullOrEmpty(name) ? this.IsStrip ? "Strip" : "Bus" : name;
                 this.AddParameter(
-                    $"VM-Strip{hi}-{cmd}",
+                        GetActionParameterName(hi,cmd),
                     this.DisplayName,
                     $"{groupName} ({hi + 1 + this.Offset})",
                     "Input"
@@ -78,20 +78,25 @@
 
             this.GetNewSettings();
         }
+        private static String GetActionParameterName(Int32 stripNumber, String cmd) => $"VM-Strip{stripNumber}-{cmd}";
 
         private void GetNewSettings()
         {
             for (var hiIndex = 0; hiIndex < this.Actions.Length; hiIndex++)
             {
+                var old = this.Actions[hiIndex];
                 this.Actions[hiIndex] =
                     (Int32)Remote.GetParameter(
                         $"{(this.IsStrip ? "Strip" : "Bus")}[{hiIndex + this.Offset}].{this.Command}");
-            }
-            if (this.Loaded) {
-	            this.AdjustmentValueChanged();
-        	}
-        }
 
+                if (this.Loaded && old != this.Actions[hiIndex])
+                {
+                    this.AdjustmentValueChanged(GetActionParameterName(hiIndex,this.Command));
+                }
+            }
+
+            
+        }
         protected override Boolean OnLoad()
         {
         	this.Loaded = true;


### PR DESCRIPTION
The other should be merged first, then I can update this branch to also use the loaded check (as otherwise it also causes exceptions).  
This should cause VM to only update the buttons that change rather than refreshing all on any dirty result.