### PR TITLE
fix: Better detection of voicemeeter version if setup exe was differently named

### DIFF
--- a/VoiceMeeterPlugin/Library/Voicemeeter/Remote.cs
+++ b/VoiceMeeterPlugin/Library/Voicemeeter/Remote.cs
@@ -225,6 +225,12 @@
                 }
 
                 var voicemeeterString = voicemeeter.ToString().Split('\\').Last();
+                var directoryName = Path.GetDirectoryName(voicemeeter.ToString());
+                if (directoryName == null)
+                {
+                    SendError(ErrorCode.NotInstalled);
+                    return null;
+                }
 
                 if (voicemeeterString.ContainsNoCase('8'))
                 {
@@ -236,15 +242,23 @@
                 }
                 else
                 {
-                    Version = RunVoicemeeterParam.Voicemeeter;
+                    //Maybe their install EXE was named something different:)
+                    var potatoPanelFile = Path.Combine(directoryName, "VBVMVAIO3_ControlPanel.exe");
+                    var bananaPanelFile = Path.Combine(directoryName, "VBVMAUX_ControlPanel.exe");
+                    if (File.Exists(potatoPanelFile))
+                    {
+                        Version = RunVoicemeeterParam.VoicemeeterPotato;
+                    }
+                    else if (File.Exists(bananaPanelFile))
+                    {
+                        Version = RunVoicemeeterParam.VoicemeeterBanana;
+                    }
+                    else
+                    {
+                        Version = RunVoicemeeterParam.Voicemeeter;
+                    }
                 }
 
-                var directoryName = Path.GetDirectoryName(voicemeeter.ToString());
-                if (directoryName == null)
-                {
-                    SendError(ErrorCode.NotInstalled);
-                    return null;
-                }
 
                 _handle = Wrapper.LoadLibrary(
                     Path.Combine(directoryName,


### PR DESCRIPTION
Turns out the features I thought were missing were not, version detection just wasn't working.

Technically the API has the option of querying the version as well, but this should work well.